### PR TITLE
ビットレート制限にニコニコ動画追加

### DIFF
--- a/src/Settings/BitrateControlSettings.jsx
+++ b/src/Settings/BitrateControlSettings.jsx
@@ -356,7 +356,10 @@ const BitrateControlSettings = ({ settings, saveSettings }) => {
           ビットレート制限 (ベータ版)
         </Typography>
         <Typography color="textSecondary">
-          実験的な機能です。現在、 YouTubeとニコニコ動画に対応しています。
+          {[
+            "実験的な機能です。現在、YouTubeとニコニコ動画に対応しています。",
+            "設定変更後の動画再生開始時の制限値に応じてビットレート選択が行われます。",
+          ].join("")}
         </Typography>
       </Box>
       <Paper>

--- a/src/Settings/BitrateControlSettings.jsx
+++ b/src/Settings/BitrateControlSettings.jsx
@@ -356,7 +356,7 @@ const BitrateControlSettings = ({ settings, saveSettings }) => {
           ビットレート制限 (ベータ版)
         </Typography>
         <Typography color="textSecondary">
-          実験的な機能です。現在、YouTubeにのみ対応しています。
+          実験的な機能です。現在、 YouTubeとニコニコ動画に対応しています。
         </Typography>
       </Box>
       <Paper>


### PR DESCRIPTION
ビットレート制限機能追加は https://github.com/videomark/sodium.js/pull/37 で対応

![Screenshot from 2020-04-08 19-00-36](https://user-images.githubusercontent.com/1730234/78771606-68b16680-79cb-11ea-8c61-b222193e3837.png)

ビットレート制限説明文にニコニコ動画を追加しました
ニコニコ動画では動画ページを複数読み込むまで反映されないので制約事項としてその旨どこかに明記する必要あると考えてます